### PR TITLE
Use `fasttext-wheel` instead of `fasttext` due to install issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ torch
 transformers
 datasets
 entmax
-fasttext
+fasttext-wheel
 fastdist
 numba
 scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     transformers>=4.0.0
     datasets
     entmax
-    fasttext
+    fasttext-wheel
     fastdist
     requests
     numpy


### PR DESCRIPTION
Fixes #4 